### PR TITLE
Adds Microsoft DI option to scan for all Modules and load them.

### DIFF
--- a/src/MediatR.Extensions.FluentBuilder.Microsoft.Tests/ServiceCollectionExtensionTests.cs
+++ b/src/MediatR.Extensions.FluentBuilder.Microsoft.Tests/ServiceCollectionExtensionTests.cs
@@ -60,5 +60,13 @@ namespace MediatR.Extensions.FluentBuilder.Tests
 
             Assert.NotEmpty(_services);
         }
+
+        [Fact]
+        public void AddModules_ShouldLoadModules()
+        {
+            _services.AddModules();
+            
+            Assert.NotEmpty(_services);
+        }
     }
 }

--- a/src/MediatR.Extensions.FluentBuilder.Microsoft/ServiceCollectionExtensions.cs
+++ b/src/MediatR.Extensions.FluentBuilder.Microsoft/ServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
@@ -46,6 +45,25 @@ namespace MediatR.Extensions.FluentBuilder
         public static IServiceCollection AddNotificationModules(this IServiceCollection services, Assembly assembly)
         {
             foreach (var module in assembly.GetNotificationModulesAs<Module>())
+            {
+                services.AddModule(module);
+            }
+
+            return services;
+        }
+
+        public static IServiceCollection AddModules(this IServiceCollection services)
+        {
+            var assemblies = AppDomain
+                .CurrentDomain
+                .GetAssemblies();
+
+            var requestModules = assemblies.SelectMany(a => a.GetRequestModulesAs<Module>());
+            var notificationModules = assemblies.SelectMany(a => a.GetNotificationModulesAs<Module>());
+
+            var allModules = requestModules.Union(notificationModules).Distinct();
+
+            foreach (var module in allModules)
             {
                 services.AddModule(module);
             }


### PR DESCRIPTION
Provides a convenience "AddAll" option to the `Microsoft DI` extension options.

I didn't update the `Automapper` option since that option already exists for them.